### PR TITLE
PLF-8073 Upgrade jdbc driver to 42.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 This add-on package a Postgresql driver for eXo Platform.
 
+See [official download page](https://jdbc.postgresql.org/) for more information.
+
+## Versions
+
+| Addon version | Jdbc Driver version | Recommanded for eXo version |
+| ------------- | ------------------- | --------------------------- |
+| 1.2.0         | 42.2.2              | 5.1.x                       |
+| 1.1.0         | 42.1.4              | 5.0.x                       |
+| 1.0.0         | 9.4.1208.jre7       | 4.4.x                       |
+
 ## Installing
 
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     </parent>
     <groupId>org.exoplatform.addons.exo-jdbc-driver-postgresql</groupId>
     <artifactId>exo-jdbc-driver-postgresql</artifactId>
-    <version>1.1.x-SNAPSHOT</version>
+    <version>1.2.x-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>eXo Platform Postresql driver</name>
     <description>eXo Platform Postgresql driver</description>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,8 @@
  02110-1301 USA, or see the FSF site: http://www.fsf.org.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>addons-parent-pom</artifactId>
@@ -42,7 +43,7 @@
         <maven.compiler.target>1.7</maven.compiler.target>
         <maven.compiler.source>1.7</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <postgresql.driver.version>42.1.4</postgresql.driver.version>
+        <postgresql.driver.version>42.2.2</postgresql.driver.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
- prepare version 1.2.x-SNAPSHOT
- Upgrade the driver to 42.2.2
- Add a link to the official page and the details of addon versions in the documentation
