### PR TITLE
Bump Driver 42.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See [official download page](https://jdbc.postgresql.org/) for more information.
 
 | Addon version | Jdbc Driver version | Recommanded for eXo version |
 | ------------- | ------------------- | --------------------------- |
-| 2.4.0         | 42.6.0              | >= 6.5.x                    |
+| 2.4.1         | 42.6.1              | >= 6.5.x                    |
 | 2.3.0         | 42.5.0              | >= 6.4.x                    |
 | 2.2.0         | 42.3.3              | >= 6.3.x                    |
 | 2.1.0         | 42.2.18             | >= 6.1.x                    |

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <postgresql.driver.version>42.6.0</postgresql.driver.version>
+        <postgresql.driver.version>42.6.1</postgresql.driver.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
Version 42.6.0 is vulnerable to [CVE-2024-1597](https://www.cve.org/CVERecord?id=CVE-2024-1597) Even if we not use the impacted parameter, it is preferable to update the version